### PR TITLE
fix: correctly check for provided dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,9 +27,9 @@ exports = module.exports = function(module) {
 
 exports.directive = directive;
 
-if (angular) {
+if ('angular' in global) {
   var mod = angular.module('timeRelative', []);
-  if (moment) {
+  if ('moment' in global) {
     mod.constant('moment', moment);
     moment.lang('en', {});
   }


### PR DESCRIPTION
My current setup inside `browserify` looks like this:

``` js
var angular = require('angular')
var ngTimeRelative = require('ng-time-relative')
var moment = require('ng-time-relative/node_modules/moment')

var app = angular.module('woop', [])
app.constant('moment', moment)
ngTimeRelative(app)
```

This way in the browser `if (moment) {`(line 30) fails with "Uncaught ReferenceError: moment is not defined ".

Correctly checking for the undefinedness of the provided modules fixes that.
